### PR TITLE
Add argument to prepend a code cell to the notebook from file

### DIFF
--- a/princess.py
+++ b/princess.py
@@ -97,6 +97,10 @@ def main(argv=None):
         '--on-error-resume-next', action='store_true',
         help="Execute remaining cells after an error"
     )
+    ap.add_argument(
+        '--prepend-code-cell', action='store', metavar='FILE',
+        help='Prepend a code cell to the notebook from file.'
+    )
 
     args = ap.parse_args(argv)
 
@@ -110,6 +114,12 @@ def main(argv=None):
         return 2
 
     nb = nbformat.read(args.notebook, as_version=4)
+
+    if args.prepend_code_cell:
+        with open(args.prepend_code_cell, 'r') as f:
+            source = f.read()
+
+        nb['cells'].insert(0, nbformat.v4.new_code_cell(source))
 
     # Remove any existing ouput before executing
     for cell in nb.cells:

--- a/tests/prepend.py
+++ b/tests/prepend.py
@@ -1,0 +1,1 @@
+print('Prepended cell')

--- a/tests/test_princess.py
+++ b/tests/test_princess.py
@@ -16,6 +16,15 @@ def test_output(capsys):
     assert 'ZeroDivisionError' in captured.out
 
 
+def test_prepend(capsys):
+    main([f'{this_dir}/Sample.ipynb',
+          '--prepend-code-cell', f'{this_dir}/prepend.py'])
+
+    captured = capsys.readouterr()
+    assert 'Prepended cell\n' in captured.out
+    assert 'Print to stdout\n' in captured.out
+
+
 def test_save(tmp_path):
     nb_orig = nbformat.read(this_dir / 'Sample.ipynb', as_version=4)
     assert nb_orig.cells[0].outputs == []


### PR DESCRIPTION
This small PR adds a new command line argument `--prepend-code-cell` to allow insertion of custom code, e.g. for intiialization, to any notebook run via Princess. Its motivation is related to set-up of logging for `pycalibration` ([internal issue](https://git.xfel.eu/calibration/planning/-/issues/149)).

Questions:
- Should this also allow insertion of markdown cells, e.g. by looking at file extension?