### PR TITLE
Add an argument to run some extra code before notebook

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.6, 3.7, 3.8, 3.9, ]
+        python-version: [ "3.7", "3.8", "3.9", "3.10" ]
     steps:
       - uses: actions/checkout@v2
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
     {name = "European XFEL GmbH", email = "da-support@xfel.eu"},
 ]
 readme = "README.rst"
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 dependencies = [
     "nbclient",
     "nbformat",

--- a/tests/test_princess.py
+++ b/tests/test_princess.py
@@ -59,11 +59,11 @@ def test_error_save(tmp_path):
     assert not new_path.exists()
 
 
-def test_extra_setup(tmp_path, monkeypatch):
+def test_run_before(tmp_path, monkeypatch):
     pre_path = tmp_path / 'pre.py'
     pre_path.write_text("open('foo.touch', 'w')\n")
 
     monkeypatch.chdir(tmp_path)
-    main([str(this_dir / 'Sample.ipynb'), '--extra-setup', str(pre_path)])
+    main([str(this_dir / 'Sample.ipynb'), '--run-before', str(pre_path)])
 
     assert (tmp_path / 'foo.touch').is_file()

--- a/tests/test_princess.py
+++ b/tests/test_princess.py
@@ -57,3 +57,13 @@ def test_error_save(tmp_path):
         str(tmp_path / 'Error.ipynb'), '--save-as', str(new_path), '--discard-on-error'
     ]) == 1
     assert not new_path.exists()
+
+
+def test_extra_setup(tmp_path, monkeypatch):
+    pre_path = tmp_path / 'pre.py'
+    pre_path.write_text("open('foo.touch', 'w')\n")
+
+    monkeypatch.chdir(tmp_path)
+    main([str(this_dir / 'Sample.ipynb'), '--extra-setup', str(pre_path)])
+
+    assert (tmp_path / 'foo.touch').is_file()


### PR DESCRIPTION
Alternative to #4 - cc @philsmt 

- What should it be called? I've put `--extra-setup` for now, but that encourages calling the file `setup.py`, which is confusing. It could be `--preamble` or `--run-before` or `--exec-first`, or...
- Should it take a file or a string of code? If a file, do we want to name it to allow for a string option later? We could also take a string and rely on shell tricks to use a file (`$(< $filename)` will [apparently](https://unix.stackexchange.com/questions/189749/understanding-bashs-read-a-file-command-substitution) do this).